### PR TITLE
Fixed a bug regarding using custom port for confluence

### DIFF
--- a/src/alfred-confluence.py
+++ b/src/alfred-confluence.py
@@ -148,7 +148,7 @@ def findConfig(args):
 
 def getBaseUrlWithoutPath(baseUrl):
     parsedBaseUrl = urlparse(baseUrl)
-    baseUrlWithoutPath = parsedBaseUrl.scheme + '://' + parsedBaseUrl.hostname
+    baseUrlWithoutPath = parsedBaseUrl.scheme + '://' + parsedBaseUrl.netloc
     return baseUrlWithoutPath
 
 


### PR DESCRIPTION
When a confluence server is hosted on custom web port, Alfred Confluence gives quick search results well, but navigates to wrong URL for found pages.

If the confluence address is `https://wiki.example.com:8443`, Alfred Confluence trys to connect `https://wiki.example.com/dosearchsite.action?queryString=[query]`, `:8443` was gone.

Here are screenshots.

----

* Pages  found

![Query succees](https://user-images.githubusercontent.com/10821289/28606957-9e6ea952-7214-11e7-93e8-43f84f1d7899.png)

* Port number has gone on navigation, so unable to see content.

![Wrong URL access](https://user-images.githubusercontent.com/10821289/28606954-9a28eeca-7214-11e7-83ea-e4080581bf65.png)

----

To fix this, this pull request changes a line of code, replacing `urlparse.hostname` to `urlparse.netloc`. I think there's no side effect on this change, here's a simple test.

```python
# cat test.py
from urlparse import urlparse

urls = ['https://c.mins.site:8443/', "https://a.b.c/", "http://confluence.example.com", "http://d.e.f:223"]

for url in urls:

    parsed = urlparse(url)

    print(parsed)
    print(parsed.hostname)
    print(parsed.netloc)
```

```
ParseResult(scheme='https', netloc='c.mins.site:8443', path='/', params='', query='', fragment='')
c.mins.site
c.mins.site:8443
ParseResult(scheme='https', netloc='a.b.c', path='/', params='', query='', fragment='')
a.b.c
a.b.c
ParseResult(scheme='http', netloc='confluence.example.com', path='', params='', query='', fragment='')
confluence.example.com
confluence.example.com
ParseResult(scheme='http', netloc='d.e.f:223', path='', params='', query='', fragment='')
d.e.f
d.e.f:223
```

I've tested on both single instance configuration and multiple instances configuration using `.alfred-confluence.json`.
