### PR TITLE
Include port number in the BaseUrlWithOutPath

### DIFF
--- a/src/alfred-confluence.py
+++ b/src/alfred-confluence.py
@@ -148,7 +148,7 @@ def findConfig(args):
 
 def getBaseUrlWithoutPath(baseUrl):
     parsedBaseUrl = urlparse(baseUrl)
-    baseUrlWithoutPath = parsedBaseUrl.scheme + '://' + parsedBaseUrl.hostname
+    baseUrlWithoutPath = parsedBaseUrl.scheme + '://' + parsedBaseUrl.netloc    
     return baseUrlWithoutPath
 
 


### PR DESCRIPTION
Included the port number in the BaseUrlWithOutPath. In this way confluence wiki's with port numbers in the base url will be properly opened in the browser.