### PR TITLE
Make the search more defensive against invalid or missing emojis

### DIFF
--- a/src/confluence-quicksearch.py
+++ b/src/confluence-quicksearch.py
@@ -197,9 +197,9 @@ def convert_to_alfred_items(search_results, args):
 
 
 def create_title(result, args):
-    if "emoji-title-published" in result["content"]["metadata"]["properties"]:
+    try:
         emoji = chr(ast.literal_eval('0x'+ result["content"]["metadata"]["properties"]["emoji-title-published"]["value"])) + ' '
-    else:
+    except Exception:
         emoji = ''
 
     return "{1}{2}".format(


### PR DESCRIPTION
I think Cloud Confluence may have updated recently or something, but I've found in the last couple weeks or so, a lot of my searches were failing.

I opened up the Workflow Debugger and found that the search was raising an exception in the `ast` module. Luckily, there's only one usage of `ast` in the script. 

Basically, I believe that Confluence has made an API change that made the original code error out on pages that don't define an emoji. I figured a `try/except` pattern would be more appropriate here; make a best effort to show the page's emoji, but if absolutely anything goes wrong with that process, just give up and show the search result without the emoji, since it's not critical.