### PR TITLE
Fix Unicode normalization for unicode search queries

### DIFF
--- a/src/confluence-quicksearch.py
+++ b/src/confluence-quicksearch.py
@@ -7,6 +7,7 @@ import re
 import requests
 import sys
 import urllib
+import unicodedata
 
 
 
@@ -30,6 +31,7 @@ def parse_args():
     
     args = parser.parse_args()
     
+    args.text = [unicodedata.normalize('NFC', text) for text in args.text]
     args.text_as_string = " ".join(args.text)
 
     args.url = validate_url(args)


### PR DESCRIPTION
Korean text searches weren't working properly due to Unicode normalization differences between macOS input (NFD format) and expected search format (NFC format). Added unicodedata.normalize('NFC', ...) to the search query processing in main() function to fix this issue.